### PR TITLE
Update links referring to EN 301 549 standard.

### DIFF
--- a/raur/index.html
+++ b/raur/index.html
@@ -276,7 +276,7 @@ This user need may also indicate necessary support for 'Total conversation' serv
 
 <p><strong>Scenario:</strong> A deaf user watching a signed broadcast needs a high&#45;quality frame rate to maintain legibility and clarity in order to understand what is being signed.</p>
 
-<p class="note">EN 301 549 Section 6,  recommends  <abbr title="Web Real&#45;time communication">WebRTC</abbr> applications should support a frame rate of at least 20 frames per second (FPS). More details can be found at <a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf"> Accessible Procurement standard for ICT products and services EN 301 549 (PDF)</a> and ITU-T Series H Supplement 1 "<a href="https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=4834&lang=en">Sign language and lip-reading real-time conversation using low bit-rate video communication</a>".</p>
+<p class="note">EN 301 549 Section 6,  recommends  <abbr title="Web Real&#45;time communication">WebRTC</abbr> applications should support a frame rate of at least 20 frames per second (FPS). More details can be found at <a href="ps://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pd"> Accessible Procurement standard for ICT products and services EN 301 549 (PDF)</a> and ITU-T Series H Supplement 1 "<a href="https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=4834&lang=en">Sign language and lip-reading real-time conversation using low bit-rate video communication</a>".</p>
 
 </section>
 
@@ -285,7 +285,7 @@ This user need may also indicate necessary support for 'Total conversation' serv
 
 <p><strong>Scenario:</strong> A hard of hearing user needs better stereo sound to have a quality experience in work calls or meetings with friends or family. Transmission aspects, such as decibel range for audio needs to be of high&#45;quality. For calls, industry allows higher audio resolution but still mostly in mono only. </p>
 
-<p class="note">EN 301 549 Section 6, recommends for <abbr title="Web Real&#45;time communication">WebRTC</abbr> enabled conferencing and communication the application shall be able to encode and decode communication with a frequency range with an upper limit of at least 7KHz. More details can be found at <a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf"> Accessible Procurement standard for ICT products and services EN 301 549 (PDF)</a></p>
+<p class="note">EN 301 549 Section 6, recommends for <abbr title="Web Real&#45;time communication">WebRTC</abbr> enabled conferencing and communication the application shall be able to encode and decode communication with a frequency range with an upper limit of at least 7KHz. More details can be found at <a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf"> Accessible Procurement standard for ICT products and services EN 301 549 (PDF)</a></p>
 </section>
 </section>
 
@@ -297,7 +297,7 @@ This user need may also indicate necessary support for 'Total conversation' serv
 
 <p class="note">A hard of hearing user often combines their perception of speech from audio with their perception of lip movement and other visual clues to create an overall understanding of speech. For the visual parts, the requirements on video are the same as expressed in '5.1 Deaf users: Video resolution and frame rates' about perception of sign language because lip movements are also part of sign language, equally rapid and as detailed as the other parts of sign language.</p>
 
-<p class="note">EN 301 549 Section 6,  recommends for <abbr title="Web Real&#45;time communication">WebRTC</abbr> enabled conferencing and communication the application shall be able to encode and decode communication with a frequency range with an upper limit of at least 7KHz. More details can be found at <a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf"> Accessible Procurement standard for ICT products and services EN 301 549 (PDF)</a></p>
+<p class="note">EN 301 549 Section 6,  recommends for <abbr title="Web Real&#45;time communication">WebRTC</abbr> enabled conferencing and communication the application shall be able to encode and decode communication with a frequency range with an upper limit of at least 7KHz. More details can be found at <a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf"> Accessible Procurement standard for ICT products and services EN 301 549 (PDF)</a></p>
 
 <p class="note"><abbr title="Web Real&#45;time communication">WebRTC</abbr> lets applications prioritise bandwidth dedicated to audio / video / data streams; there is also some experimental work in signalling these needs to the network layer as well as support for prioritising frame rate over resolution in case of congestion. [[webrtc-priority]]</p>
 


### PR DESCRIPTION
These are the RTC Accessibility User Requirements-specific changes necessary to
update references to EN 301 549. In this case, they are links within the
document itself.
