### PR TITLE
Update README file to refer potential contributors to the new repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Many of the deliverables formerly maintained here have now been moved to individ
 
 | Document Title                                             | New Location                                                               |
 |:-----------------------------------------------------------|:---------------------------------------------------------------------------|
+| Framework for Accessible Specification of Technologies     | [w3c/fast](https://github.com/w3c/fast/)                                                                           |
 | Inaccessibility of CAPTCHA                                 | [w3c/captcha-accessibility](https://github.com/w3c/captcha-accessibility/) |
 | Accessibility of Remote Meetings                           | [w3c/remote-meetings](https://github.com/w3c/remote-meetings/)             |
 | Synchronization Accessibility User Requirements            | [w3c/saur](https://github.com/w3c/saur/)                                   |
 | Natural Language Interface Accessibility User Requirements | [w3c/naur](https://github.com/w3c/naur/)                                   |
 | RTC Accessibility User Requirements                        | [w3c/raur](https://github.com/w3c/raur/)                                   |
-| XR Accessibility User Requirements                         | [w3c/xaur](https://github.com/w3c/xaur/)                                                                           |
+| XR Accessibility User Requirements                         | [w3c/xaur](https://github.com/w3c/xaur/)                                   |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # apa
 Accessible Platform Architectures WG deliverables
+
+# Important Note
+Many of the deliverables formerly maintained here have now been moved to individual repositories, as detailed in the table below. Future GitHub issues or pull requests should be contributed to the new repositories. Such contributions are welcome.
+
+| Document Title                                             | New Location                                                               |
+|:-----------------------------------------------------------|:---------------------------------------------------------------------------|
+| Inaccessibility of CAPTCHA                                 | [w3c/captcha-accessibility](https://github.com/w3c/captcha-accessibility/) |
+| Accessibility of Remote Meetings                           | [w3c/remote-meetings](https://github.com/w3c/remote-meetings/)             |
+| Synchronization Accessibility User Requirements            | [w3c/saur](https://github.com/w3c/saur/)                                   |
+| Natural Language Interface Accessibility User Requirements | [w3c/naur](https://github.com/w3c/naur/)                                   |
+| RTC Accessibility User Requirements                        | [w3c/raur](https://github.com/w3c/raur/)                                   |
+| XR Accessibility User Requirements                         | [w3c/xaur](https://github.com/w3c/xaur/)                                                                           |


### PR DESCRIPTION
Update the README.md file to note the new repositories and to provide a table identifying the repository for each document that has been moved.

Only RQTF documents are covered for now, but this could easily be expanded to include other APA publications, if this approach is approved.
Closes #306.
