### PR TITLE
APA charter: restore open test suite of every feature requirement

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -328,6 +328,7 @@ new WAI-Adapt Complexity Semantics Module.</p>
       <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable
         implementations</a> of every feature defined in the specification, where
       interoperability can be verified by passing open test suites.
+	In order to advance beyond Candidate Recommendation, each normative specification must have an open test suite of every feature defined in the specification.
     </p>
     <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 	 


### PR DESCRIPTION
Similar to the fix we suggested to the Media Working Group charter in https://github.com/w3c/charter-media-wg/pull/53 (which was accepted and merged).

restore the "open test suite of every feature" requirement in Success Criteria from prior charter.
* There was no specific reason given to loosen this requirement