### PR TITLE
Updates to the fixing-idrefs presentation:

### DIFF
--- a/presentations/2025/TPAC/fixing-idrefs/index.html
+++ b/presentations/2025/TPAC/fixing-idrefs/index.html
@@ -77,17 +77,13 @@
   </section>
 
 
-  <section class="slide" id="goals">
-    <h2>Goals</h2>
+  <section class="slide" id="">
+    <h2>Goals for this session</h2>
+    <p>To find areas of consensus regarding</p>
     <ul>
-      <li class=next>(Roughly) describe the problem</li>
-      <li class=next>Sketch some possible solutions</li>
-      <li class=next>Main part: discussion
-        <ul>
-          <li class=next>Concerns, questions, research needed</li>
-          <li class=next>Work towards consensus on the above</li>
-        </ul>
-      </li>
+      <li class="next">the pain points of IDREFs</li>
+      <li class="next">expected costs and risks from an accessibility perspective</li>
+      <li class="next">the possibilities for conducting research to quantify the above</li>
     </ul>
   </section>
 
@@ -101,18 +97,18 @@
   </section>
 
 
-  <section class="slide" id="lists">
-    <h2>Detailed Overview</h2>
+  <section class="slide" id="agenda">
+    <h2>Agenda</h2>
     <ul>
-      <li>Fixing?
+      <li class=next>What (if anything) needs fixing?</li>
+      <li class=next>Prior art</li>
+      <li class=next>Main part: discussion
         <ul>
-          <li>What are the pain points?</li>
-          <li>Our thoughts on what they may be</li>
+          <li class=next>Work towards consensus on the problem space</li>
+          <li class=next>Discuss constraints on solutions</li>
+          <li class=next>Concerns, questions, research needed</li>
         </ul>
       </li>
-      <li>Ideas</li>
-      <li>Concerns</li>
-      <li>Research</li>
     </ul>
   </section>
 
@@ -144,6 +140,27 @@
 
 
   <section class="slide">
+    <h2>What (if anything) needs fixing?</h2>
+    <p>Themes from developer feedback so far:</p>
+    <ul>
+      <li>Repeated content requires rewriting IDs for each repetition</li>
+      <li>Combining content from multiple sources can cause ID collisions</li>
+      <li>No platform support for generating/managing unique IDs
+        <ul>
+          <li>Being forced to add a build step or use JS</li>
+        </ul>
+      </li>
+      <li>Unergonomic using IDs for label/input association in particular
+        <ul>
+          <li>Many also commented that nesting inputs within labels is frowned upon</li>
+        </ul>
+      </li>
+      <li>Inline SVG using fragment identifiers can also easily cause collisions</li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
     <h2>General concerns</h2>
     <div class=columns>
       <div>
@@ -169,95 +186,153 @@
   </section>
 
 
-  <section class=slide>
-    <h2>Some approaches&hellip;</h2>
-    <p>The following sections outline <em>some</em> possible solutions.</p>
+  <section class="slide">
+    <h2>Prior art: <code>useId()</code></h2>
+    <ul>
+      <li>Provided by component frameworks Vue and React</li>
+      <li>Generates a unique ID which can be used in templates</li>
+      <li>IDs are stable across multiple runs, as long as an element is in the same position in the tree</li>
+    </ul>
+  </section>
+
+  <section class="slide">
+    <h2>Prior art: <code>useId()</code></h2>
+    <pre>export default function FormComponent() {
+  const inputId = useId();
+
+  return (
+    &lt;form&gt;
+      &lt;label htmlFor={inputId}&gt
+        Enter your name:
+      &lt;/label&gt;
+      &lt;input id={inputId} type="text" /&gt;
+    &lt;/form&gt;
+  );
+}</pre>
   </section>
 
 
   <section class="slide">
-    <h2>Keep using existing tooling for scoping</h2>
-    <p>Don't add anything; just use existing tools such as React's <code>useId</code> et al to solve the problem.</p>
-    <div class=columns>
+    <h2>Prior art: <code>useId()</code></h2>
+    <p>The code on the previous slide my result in HTML something like this:</p>
+    <pre>&lt;form&gt;
+  &lt;label for=":r1:"&gt;Enter your name:&lt;/label&gt;
+  &lt;input id=":r1:" type="text"&gt;
+&lt;/form&gt;
+</pre>
+  </section>
+
+
+  <section class="slide">
+    <h2>Prior art: ID prefixing</h2>
+    <ul>
+      <li>A unique string is added to IDs in repeated content</li>
+      <li>The unique string may be generated or author-supplied</li>
+      <li>There are build tools which do this specifically, and it can also be done using something like <code>useId()</code></li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <h2>Prior art: ID prefixing</h2>
+    <pre>export default function FormComponent() {
+  const prefix = useId();
+
+  return (
+    &lt;form&gt;
+      &lt;label htmlFor={prefix + '-first'}&gtFirst name:&lt;/label&gt;
+      &lt;input id={prefix + '-first'} type="text" /&gt;
+      &lt;br /&gt;
+      &lt;label htmlFor={prefix + '-last'}&gtLast name:&lt;/label&gt;
+      &lt;input id={prefix + '-last'} type="text" /&gt;
+    &lt;/form&gt;
+  );
+}</pre>
+  </section>
+
+
+  <section class="slide">
+    <h2>Prior art: ID prefixing</h2>
+    <ul>
+      <li><code>posthtml-rename-id</code> is a plugin for PostHTML which specifically handles ID usage in SVG and CSS fragment identifiers</li>
+      <li>Fragment identifiers are used in in-page links (<code>&lt;a href="#myId"&gt;</code>),
+      CSS values (<code>fill: url(#myId)</code>) and SVG <code>href</code> attributes and
+      <code>url()</code> values</li>
+    </ul>
+    <div class="columns">
       <div>
-        <h3>Pros</h3>
-        <ul>
-          <li>No changes needed to UA or AT code; no performacne burden.</li>
-        </ul>
+        <h3>Input</h3>
+        <pre>&lt;style>
+.selector {
+  fill: url(#myId);
+}
+&lt;/style>
+
+&lt;div id="myId">&lt;/div>
+&lt;a href="#myId">&lt;/a></pre>
       </div>
       <div>
-        <h3>Cons</h3>
-        <ul>
-          <li>May not adequately solve the problem?</li>
-        </ul>
+        <h3>Output</h3>
+        <pre>&lt;style>
+.selector {
+  fill: url(#prefix_myId);
+}
+&lt;/style>
+
+&lt;div id="prefix_myId">&lt;/div>
+&lt;a href="#prefix_myId">&lt;/a></pre>
       </div>
     </div>
   </section>
 
 
   <section class="slide">
-    <h2>Scoping via an attribute or element</h2>
-    <p>Use an attribute or element to define regions of the DOM within which IDREFs must be unique.</p>
-    <div class=columns>
-      <div>
-        <h3>Pros</h3>
-        <ul>
-          <li>Relatively simple authoring change</li>
-          <li>Wide applicability</li>
-        </ul>
-      </div>
-      <div>
-        <h3>Cons</h3>
-        <ul>
-          <li>UA/AT has to track backreferences (development burden)</li>
-          <li>UA/AT has to track DOM manipulations (performance burden)</li>
-        </ul>
-      </div>
-    </div>
+    <h2>Prior art: Scoped ID rewriting</h2>
+    <ul>
+      <li>Lets developers annotate a parent node to define a "group", within which all IDs are rewritten in a consistent way by the framework</li>
+      <li>In practice, this is similar to ID prefixing, but doesn't require developers to specify how to do the rewriting</p>
+  </section>
+
+  <section class="slide">
+    <h2>Prior art: Scoped ID rewriting</h2>
+    <h3>AlpineJS <code>x-id</code> and <code>$id</code></h3>
+    <pre>&lt;!-- rewrite 'input' in this scope -->
+&ltdiv x-id="['input']">
+    &lt;label :for="$id('input')"> &lt;!-- "input-1" -->
+    &lt;input :id="$id('text-input')"> &lt;!-- "input-1" -->
+&lt;/div>
+
+&lt;!-- rewrite 'input' (differently) in this scope too -->
+&lt;div x-id="['input']">
+    &lt;label :for="$id('input')"> &lt;!-- "input-2" -->
+    &lt;input :id="$id('input')"> &lt;!-- "input-2" -->
+&lt;/div></pre>
   </section>
 
 
   <section class="slide">
-    <h2>Unique ID generation in templates</h2>
-    <p>Provide platform-native feature to ensure unique IDREFs are genrated, but only in <code>&lt;template&gt;</code>
-      elements.</p>
-    <div class=columns>
-      <div>
-        <h3>Pros</h3>
-        <ul>
-          <li>Only the parser needs to change (no need to deal with backreferences).</li>
-        </ul>
-      </div>
-      <div>
-        <h3>Cons</h3>
-        <ul>
-          <li>Feature not available across the platform</li>
-        </ul>
-      </div>
-    </div>
+      <h2>Prior art: Using selectors to refer to elements</h2>
+      <ul>
+        <li>This allows framework authors to specify an element as a target of some framework property via a selector, or selector-like string</li>
+        <li>This seems to be used less for platform features like label/for, and more for intra-framework operations</li>
+        <li>Example code for this style of writing predominantly uses `#myId` selectors</li>
+      </ul>
   </section>
 
 
   <section class="slide">
-    <h2>Relative element pointers</h2>
-    <p>Use CSS selectors to refer to elements based on DOM structure.</p>
-    <p>FIXME example</p>
-    <div class=columns>
-      <div>
-        <h3>Pros</h3>
-        <ul>
-          <li>No need to make up IDs</li>
-        </ul>
-      </div>
-      <div>
-        <h3>Cons</h3>
-        <ul>
-          <li>Fragile/unstable for accessibility?</li>
-          <li>Complex to interprest?</li>
-          <li>Applicability to HTML in the wild?</li>
-        </ul>
-      </div>
-    </div>
+      <h2>Prior art: Using selectors to refer to elements</h2>
+      <h3>htmx <code>hx-target</code></h3>
+      <pre>&lt;!--A button that causes response-div to be updated-->
+&lt;div>
+  &lt;div id="response-div">&lt;/div>
+  &lt;button hx-post="/register" hx-target="#response-div" hx-swap="beforeend">
+    Register!
+  &lt;/button>
+&lt;/div>
+
+&lt;!-- A link that updates itself when clicked-->
+&lt;a hx-post="/new-link" hx-target="this" hx-swap="outerHTML">New link&lt;/a></pre>
   </section>
 
 
@@ -280,7 +355,7 @@
   </section>
 
   <section class=slide>
-    <p class=huge>Would you find relative references useful?</p>
+    <p class=huge>What other approaches have been used in libraries or tooling?</p>
   </section>
 
   <section class=slide>
@@ -299,18 +374,16 @@
     <p class=huge>How would any particular change benefit users?</p>
   </section>
 
+  <section class="slide">
+    <p class=huge>What other constraints would you want on the potential solution space?</p>
+  </section>
+
   <section class=slide>
     <h2>Research</h2>
     <p class=next>We need to do research to identify the problems. That starts with <em>you</em>!</p>
     <p class=next>How can we ensure that the reseach is effective?</p>
     <p class=next>Can you help?</p>
     <p class=next>Some experiences of developers we've collected&hellip;</p>
-  </section>
-
-
-  <section class=slide>
-    <h2>Excerpts from the HedgeDoc</h2>
-    <p>FIXME: Here I would put some quotes from the HedgeDoc.</p>
   </section>
 
 
@@ -347,10 +420,124 @@
           <li><a href="https://github.com/whatwg/html/issues/10143#issuecomment-3195739405">Alice's summary</a></li>
         </ul>
       </li>
+      <li><a href="https://github.com/webplatformco/project-idrefs/blob/main/research.md">Collation of feedback</a> from State of HTML surveys, selected GitHub issues, and social media.</li>
       <li><a href="https://notes.igalia.com/XlsPwU5sQfuaWYHwhtBMtA">Feedback on IDREF questions</a>&mdash;document
-        containing some questions for developers, and some answers from developers.</li>
+        containing the questions Alice proposed in the summary comment above, and some answers from developers.</li>
       <li><a href="https://www.w3.org/2025/10/15-apa-minutes.html">Minutes from <abbr
             title="Accessible Platform Architectures">APA</abbr> WG call</a></li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <p class=huge>Appendix: Quotes from developers </h2>
+  </section>
+
+  <section class="slide">
+    <h2>Theme: repeated content</h2>
+    <ul>
+      <li>"labels use the ID, so you can't repeat similar forms and instead have to dynamically
+      generate unique IDs for every form"</li>
+      <li>"The biggest pain point about IDs is the need for whole-page uniqueness, which conflicts
+      with component-based templates, especially when there are repeated components."</li>
+      <li>"IDs don't work well with repeated content blocks, you have to uniquify them and refer to
+      that unique'd name"</li>
+      <li>"[...] templates where I need to relate two elements together using an id [...] and the
+      template is usually repeated in the page."</li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <h2>Theme: unique ID generation</h2>
+    <ul>
+      <li>"The platform doesn't help with basic needs like creating unique IDREFs."</li>
+      <li>"Getting my developer community to care about generating unique IDs for every input is too
+      hard; they aren't doing it and our code is inaccessible."</li>
+      <li>"having to come up with unique ids"</li>
+      <li>"Html ul li counters as native performant unique ID generators would enable so much
+      functionality, it's hard to think of all the use cases."</li>
+      <li>"I never found myself in a case where a random uuid or a framework provided tool didn't
+      solve the issue."</li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <h2>Theme: unique ID generation</h2>
+    <h3>Sub-theme: stable IDs</h3>
+    <ul>
+      <li>"Guaranteeing uniqueness on a page and keeping that uniqueness consistent across page
+      renderings (e.g. if list elements have IDs, and an item gets inserted, do IDs remain
+      consistent?) </li>
+      <li>"Random UUIDs not being ideal in static site generation as every page would be different
+      in every build, making selective syncing of actually changed pages to storage
+      impossible."</li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <h2>Theme: label/input</h2>
+    <ul>
+      <li>"ids for everything for labels even though they're siblings"</li>
+      <li>"Absolute ids for label input relations. Wish to have relative, form - scoped binding</li>
+      <li>"settings ids and labels is very repetitive"</li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <h2>Theme: label/input</h2>
+    <h3>Sub-theme: label/input wrapping</h3>
+    <ul>
+      <li>"Use to be if you nested an input within a label that was good enough to establish a
+      relationship but now we always need ids which seems like overkill."</li>
+      <li>"That nesting inputs in labels have fallen out of favor and ids are wanted for nested
+      inputs"</li>
+      <li>"the wrapping does not always make sense to the structure and we don't always want to
+      create ids just for the labels"</li>
+      <li>"the fact that wrapping an input with <code>&lt;label&gt;</code> is not recommended for
+      accessibility means ensuring unique ids per field"</li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <h2>Theme: SVG</h2>
+    <ul>
+      <li>"state of SVG url references and canvas filter ids inside shadow DOMs"</li>
+      <li>"SVG masks requiring unique IDs"</li>
+      <li>"IDs in inline SVGs needing to be unique on the page"</li>
+      <li>"In SVG, for example, defining a gradient requires creating a <code>&lt;defs&gt;</code> block,
+      assigning it an <code>id</code>, and referencing it using <code>url(#id)</code> inside the
+      same SVG. When that SVG is duplicated (for example, multiple icons on a page), all those
+      references end up pointing to the first matching ID in the document."</li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <h2>Theme: unique ID generation</h2>
+    <h3>Sub-theme: getting generated IDs to both ends of a pair</h3>
+    <ul>
+      <li>"Generating unique-but-matching for-ID pairs in component-based dev frameworks, especially
+      when the actual input is separated from its label and potentially seventeen levels deeper. "</li>
+      <li>"Passing ids betwen files [in component libraries] is tricky."</li>
+      <li>"whole page uniqueness [is] a bit tricky to satisfy in some rare situations because the
+      different elements linked by the IDREF are not in the same component."</li>
+    </ul>
+  </section>
+
+
+  <section class="slide">
+    <h2>Theme: JS/toolchain requirement</h2>
+    <ul>
+      <li>"Frequently have to append a uuid or database ID to make it prefixed but unique, which
+      means JS required."</li>
+      <li>"Most current solutions depend on external tools to handle [ID prefixing] automatically,
+      but that often makes things worse in real projects due to tool limitations or collisions in
+      the processing pipeline."</li>
     </ul>
   </section>
 


### PR DESCRIPTION
- Edit "goals" to match the session outline
- Add a summary of themes from developer feedback
- Add prior art section
- Add long-form examples of developer feedback as an appendix.

Preview: https://alice.github.io/apa/presentations/2025/TPAC/fixing-idrefs/index.html